### PR TITLE
Fixed bug causing crash on startup if Data dir not present.

### DIFF
--- a/CMAN.py
+++ b/CMAN.py
@@ -247,7 +247,10 @@ if (os.path.exists("LocalData/ModsDownloaded") == False):
 	os.mkdir("LocalData/ModsDownloaded")
 execdir = os.getcwd()
 print(execdir)
-shutil.rmtree("Data") #deleting Data dir
+try:
+	shutil.rmtree("Data") #deleting Data dir
+except(FileNotFoundError): #Data dir not present
+	pass
 os.mkdir("Data") #creating new Data dir
 
 


### PR DESCRIPTION
When I changed the Data dir cleanup code, I forgot to check for the possibility that the Data dir is not present. This resulted in a FileNotFoundException on startup. This commit should fix it (I've tested it without a data dir and it created one and started up fine).